### PR TITLE
cmd_vel to 0 when deadman button is released

### DIFF
--- a/turtlebot_teleop/src/turtlebot_joy.cpp
+++ b/turtlebot_teleop/src/turtlebot_joy.cpp
@@ -97,6 +97,9 @@ void TurtlebotTeleop::publish()
   if (deadman_pressed_)
   {
     vel_pub_.publish(last_published_);
+  }else
+  {
+    vel_pub_.publish(*new geometry_msgs::Twist());
   }
 
 }


### PR DESCRIPTION
Hi,
I am not sure if this was the right behaviour but using the node in simulation I've found out that the robot kept following the last velocity command after deadman button was released.
To fix that I published a zero twist when deadman_pressed_ is false.
Cheers.
