### PR TITLE
Implement automatic calibration system

### DIFF
--- a/turtlebot_calibration/launch/calibrate.launch
+++ b/turtlebot_calibration/launch/calibrate.launch
@@ -1,5 +1,13 @@
 <launch>
-  <include file="$(find turtlebot_bringup)/launch/3dsensor.launch"/>
+  <include file="$(find turtlebot_bringup)/launch/3dsensor.launch">
+    <arg name="rgb_processing" value="false" />
+    <arg name="depth_registration" value="false" />
+    <arg name="depth_processing" value="false" />
+
+    <!-- We must specify an absolute topic name because if not it will be prefixed by "$(arg camera)".
+         Probably is a bug in the nodelet manager: https://github.com/ros/nodelet_core/issues/7 --> 
+    <arg name="scan_topic" value="/scan" />
+  </include>
 
   <node pkg="turtlebot_calibration" type="scan_to_angle.py" name="scan_to_angle" >
     <param name="min_angle" value="-0.3" />

--- a/turtlebot_calibration/src/turtlebot_calibration/calibrate.py
+++ b/turtlebot_calibration/src/turtlebot_calibration/calibrate.py
@@ -233,9 +233,12 @@ def writeParamsToCalibrationFile(newparams):
             d[k] = v
         newparams = d
         f.close()
-    os.makedirs(calib_dir)
+    try:
+        os.makedirs(calib_dir)
+    except:
+        pass
     with open(calib_file, 'w') as outfile:
-        outfile.write( yaml.dump(newparams, default_flow_style=True) )
+        outfile.write( yaml.dump(newparams, default_flow_style=False) )
     rospy.loginfo("Saved the params to the calibration file: %s" % calib_file)
 
 def writeParamsToLaunchFile(gyro, odom, gyro_range):
@@ -298,7 +301,7 @@ def main():
 
     newparams = {'gyro_scale_correction' : imu_res, 'odom_angular_scale_correction' : odom_res, 'gyro_measurement_range' : gyro_range}
     writeParamsToCalibrationFile(newparams)
-    writeParams(newparams)
+    writeParams(drclient, newparams)
 
 if __name__ == '__main__':
     main()

--- a/turtlebot_calibration/src/turtlebot_calibration/calibrate.py
+++ b/turtlebot_calibration/src/turtlebot_calibration/calibrate.py
@@ -203,20 +203,21 @@ class CalibrateRobot:
 
 def get_usb_to_serial_id():
     usbpath = subprocess.check_output("readlink -f /sys/class/tty/ttyUSB0", shell=True)
-    if len(usbpath.strip()) == 0:
+    usbpath = usbpath.strip()
+    if len(usbpath) == 0:
         return None
     serialid = ""
     try:
-        f = open(usbpath + "../../../../serial", "r")
+        f = open(usbpath + "/../../../../serial", "r")
         serialid = f.read().strip()
         f.close()
     except:
         pass
     try:
-        f = open(usbpath + "../../../../idVendor", "r")
+        f = open(usbpath + "/../../../../idVendor", "r")
         serialid += f.read().strip()
         f.close()
-        f = open(usbpath + "../../../../idProduct", "r")
+        f = open(usbpath + "/../../../../idProduct", "r")
         serialid += f.read().strip()
         f.close()
     except:

--- a/turtlebot_calibration/src/turtlebot_calibration/calibrate.py
+++ b/turtlebot_calibration/src/turtlebot_calibration/calibrate.py
@@ -47,7 +47,10 @@ from geometry_msgs.msg import Twist
 from turtlebot_calibration.msg import ScanAngle
 from math import *
 import threading
-
+import dynamic_reconfigure.client
+import os
+import subprocess
+import yaml
 
 def quat_to_angle(quat):
     rot = PyKDL.Rotation.Quaternion(quat.x, quat.y, quat.z, quat.w)
@@ -198,6 +201,40 @@ class CalibrateRobot:
             self.scan_angle = angle
             self.scan_time = msg.header.stamp
 
+def get_kinect_serial():
+    ret = subprocess.check_output("lsusb -v -d 045e:02ae | grep Serial | awk '{print $3}'", shell=True)
+    if len(ret) > 0:
+        return ret.strip()
+    return None
+   
+def getCurrentParams(drclient):
+    allparams = drclient.get_configuration()
+    return (allparams['gyro_scale_correction'], allparams['odom_angular_scale_correction'])
+
+def writeParams(drclient, newparams):
+    r = drclient.update_configuration(newparams) 
+    rospy.loginfo("Automatically updated the params in the current running instance of ROS, no need to restart.")
+
+def writeParamsToCalibrationFile(newparams):
+    kinect_serial = get_kinect_serial()
+    if kinect_serial is None:
+        return
+    ros_home = os.environ.get('ROS_HOME')
+    if ros_home is None:
+        ros_home = "~/.ros"
+    calib_file = os.path.expanduser(ros_home +"/turtlebot_create/" +str(kinect_serial) + ".yaml")
+    # if the file exists, load into a dict, update the new params, and then save
+    if os.path.isfile(calib_file):
+        f = open(calib_file, 'r')
+        docs = yaml.load_all(f)
+        d = docs.next()
+        for k,v in newparams.iteritems():
+            d[k] = v
+        newparams = d
+        f.close()
+    with open(calib_file, 'w') as outfile:
+        outfile.write( yaml.dump(newparams, default_flow_style=True) )
+    rospy.loginfo("Saved the params to the calibration file: %s" % calib_file)
 
 def writeParamsToLaunchFile(gyro, odom):
     try:
@@ -226,6 +263,7 @@ def writeParamsToLaunchFile(gyro, odom):
 def main():
     rospy.init_node('scan_to_angle')
     robot = CalibrateRobot()
+    imu_res = 1.0
     
     imu_drift = robot.imu_drift()
     imu_corr = []
@@ -236,15 +274,20 @@ def main():
         if imu:
             imu_corr.append(imu)
         odom_corr.append(odom)
-
+    
+    drclient = dynamic_reconfigure.client.Client("turtlebot_node")
+    (prev_gyro, prev_odom) = getCurrentParams(drclient)
     if len(imu_corr)>0:    
-        imu_res = 1.0/(sum(imu_corr)/len(imu_corr))
-        rospy.loginfo("Multiply the 'turtlebot_node/gyro_scale_correction' parameter with %f"%imu_res)
+        imu_res = prev_gyro * (1.0/(sum(imu_corr)/len(imu_corr)))
+        rospy.loginfo("Set the 'turtlebot_node/gyro_scale_correction' parameter to %f"%imu_res)
 
-    odom_res = 1.0/(sum(odom_corr)/len(odom_corr))
-    rospy.loginfo("Multiply the 'turtlebot_node/odom_angular_scale_correction' parameter with %f"%odom_res)
+    odom_res = prev_odom * (1.0/(sum(odom_corr)/len(odom_corr)))
+    rospy.loginfo("Set the 'turtlebot_node/odom_angular_scale_correction' parameter to %f"%odom_res)
     writeParamsToLaunchFile(imu_res, odom_res)
 
+    newparams = {'gyro_scale_correction' : imu_res, 'odom_angular_scale_correction' : odom_res}
+    writeParamsToCalibrationFile(newparams)
+    writeParams(newparams)
 
 if __name__ == '__main__':
     main()

--- a/turtlebot_calibration/src/turtlebot_calibration/calibrate.py
+++ b/turtlebot_calibration/src/turtlebot_calibration/calibrate.py
@@ -222,7 +222,8 @@ def writeParamsToCalibrationFile(newparams):
     ros_home = os.environ.get('ROS_HOME')
     if ros_home is None:
         ros_home = "~/.ros"
-    calib_file = os.path.expanduser(ros_home +"/turtlebot_create/" +str(kinect_serial) + ".yaml")
+    calib_dir = os.path.expanduser(ros_home +"/turtlebot_create/")
+    calib_file = calib_dir +str(kinect_serial) + ".yaml")
     # if the file exists, load into a dict, update the new params, and then save
     if os.path.isfile(calib_file):
         f = open(calib_file, 'r')
@@ -232,6 +233,7 @@ def writeParamsToCalibrationFile(newparams):
             d[k] = v
         newparams = d
         f.close()
+    os.makedirs(calib_dir)
     with open(calib_file, 'w') as outfile:
         outfile.write( yaml.dump(newparams, default_flow_style=True) )
     rospy.loginfo("Saved the params to the calibration file: %s" % calib_file)


### PR DESCRIPTION
This patchset makes a number of improvements to turtlebot_calibration to make it nearly automatic:
1.  Retrieve the current calibration parameters from dynamic_reconfigure and use them to calculate the new parameters, no more manual multiplying
2.  Apply the new parameters to the currently running ros instance using dynamic_reconfigure, no more restarting the turtlebot
3.  Add warnings and references about the gyro range parameter, since this seems to be the biggest hangup for new users
4.  Use the Kinect's serial number (or the usb <-> serial adapter's id if no kinect is available) to save the calibration settings in a standard location.  These settings can then be used by a load script during the turtlebot bringup to help take the pain out of dealing with multiple turtlebots. See this pull request for more information: https://github.com/turtlebot/turtlebot_create/pull/14
5.  Fix the scan topic issues for now, closes issue #69

This patchset (and the referenced pull) have allowed me to quickly calibrate all of my turtlebots and copy the resulting configurations to all laptops.  Since it's nearly automatic it could also be used as part of a script, for instance calibrating the robot before doing something else.
