### PR TITLE
Correct the max range to match the default for the kinect

### DIFF
--- a/turtlebot_navigation/launch/includes/gmapping.launch.xml
+++ b/turtlebot_navigation/launch/includes/gmapping.launch.xml
@@ -6,7 +6,7 @@
     <param name="odom_frame" value="odom"/>
     <param name="map_update_interval" value="5.0"/>
     <param name="maxUrange" value="6.0"/>
-    <param name="maxRange" value="8.0"/>
+    <param name="maxRange" value="10.1"/>
     <param name="sigma" value="0.05"/>
     <param name="kernelSize" value="1"/>
     <param name="lstep" value="0.05"/>


### PR DESCRIPTION
This allows empty space to be placed in the map for out of usable range scans.  The default maxRange of the depthimage_to_laserscan package is 10 so this package should be updated accordingly.  Without it empty space is not added to the generated map except when the turtlebot is within maxRange, which makes large spaces hard to map.
