### PR TITLE
Change map_nav qt map_server node to pull from environment variable

### DIFF
--- a/turtlebot_rapps/rapps/map_nav/map_nav.launch
+++ b/turtlebot_rapps/rapps/map_nav/map_nav.launch
@@ -47,7 +47,7 @@
   </include>
 
   <!-- Maps -->
-  <arg name="map_file" default="$(find turtlebot_navigation)/maps/willow-2010-02-18-0.10.yaml"/>
+  <arg name="map_file" default=" $(env MAP_FILE)" /> <!-- User must set this environment variable for map_server to work -->
   <node name="map_server" pkg="map_server" type="map_server" args="$(arg map_file)" />
 
   <param name="warehouse_host" value="localhost"/>


### PR DESCRIPTION
Change to allow users with install from Debs to change which map to load  into map_server for Qt map_nav.
