### PR TITLE
Change build commands to fix break caused by Eigen package moving

### DIFF
--- a/turtlebot_actions/CMakeLists.txt
+++ b/turtlebot_actions/CMakeLists.txt
@@ -4,6 +4,7 @@ project(turtlebot_actions)
 # Load catkin and all dependencies required for this package
 find_package(catkin REQUIRED COMPONENTS cmake_modules roscpp actionlib actionlib_msgs geometry_msgs message_generation tf cv_bridge image_transport image_geometry)
 find_package(Boost REQUIRED COMPONENTS system)
+find_package(cmake_modules REQUIRED)
 find_package(Eigen REQUIRED)
 find_package(OpenCV REQUIRED)
 

--- a/turtlebot_actions/package.xml
+++ b/turtlebot_actions/package.xml
@@ -14,6 +14,7 @@
   
   <buildtool_depend>catkin</buildtool_depend>
   
+  <build_depend>cmake_modules</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>actionlib</build_depend>
   <build_depend>actionlib_msgs</build_depend>

--- a/turtlebot_panorama/CMakeLists.txt
+++ b/turtlebot_panorama/CMakeLists.txt
@@ -4,6 +4,7 @@ project(turtlebot_panorama)
 # Load catkin and all dependencies required for this package
 find_package(catkin REQUIRED COMPONENTS cmake_modules roscpp actionlib std_msgs std_srvs nav_msgs sensor_msgs geometry_msgs turtlebot_msgs image_transport pano_ros)
 find_package(Boost REQUIRED COMPONENTS system)
+find_package(cmake_modules REQUIRED)
 find_package(Eigen REQUIRED)
 
 # What other packages will need to use this package

--- a/turtlebot_panorama/package.xml
+++ b/turtlebot_panorama/package.xml
@@ -15,6 +15,7 @@
   
   <buildtool_depend>catkin</buildtool_depend>
   
+  <build_depend>cmake_modules</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>actionlib</build_depend>
   <build_depend>cmake_modules</build_depend>


### PR DESCRIPTION
The Eigen package moved to cmake_modules in indigo, so the CMakeLists.txt and package files for the two packages that depend on it had to be changed, per http://wiki.ros.org/indigo/Migration
