### PR TITLE
reduce max_rot_vel to 0.5

### DIFF
--- a/turtlebot_navigation/param/dwa_local_planner_params.yaml
+++ b/turtlebot_navigation/param/dwa_local_planner_params.yaml
@@ -15,7 +15,7 @@ DWAPlannerROS:
   #   do not set min_trans_vel to 0.0 otherwise dwa will always think translational velocities
   #   are non-negligible and small in place rotational velocities will be created.
 
-  max_rot_vel: 5.0  # choose slightly less than the base's capability
+  max_rot_vel: 0.5  # choose slightly less than the base's capability
   min_rot_vel: 0.4  # this is the min angular velocity when there is negligible translational velocity
   rot_stopped_vel: 0.4
   


### PR DESCRIPTION
I followed  http://wiki.ros.org/turtlebot_gazebo/Tutorials/indigo/Make%20a%20map%20and%20navigate%20with%20it tutorial and found strange behavior of the robot.
It rotate around during move to the target 

This PR fixes in simulation, but I'm not sure what is the correct value for the real robot. Where can I find specification sheet for the base system.

![rotate_bot](https://cloud.githubusercontent.com/assets/493276/10779502/23961b56-7d75-11e5-8da5-b23d27eb8fed.gif)
