### PR TITLE
adding joystick_follower demo application

### DIFF
--- a/turtlebot_joystick_follower/CMakeLists.txt
+++ b/turtlebot_joystick_follower/CMakeLists.txt
@@ -1,0 +1,170 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(turtlebot_joystick_follower)
+
+## Find catkin macros and libraries
+## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
+## is used, also find other catkin packages
+find_package(catkin REQUIRED COMPONENTS
+  std_msgs
+  topic_tools
+)
+
+## System dependencies are found with CMake's conventions
+# find_package(Boost REQUIRED COMPONENTS system)
+
+
+## Uncomment this if the package has a setup.py. This macro ensures
+## modules and global scripts declared therein get installed
+## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
+# catkin_python_setup()
+
+################################################
+## Declare ROS messages, services and actions ##
+################################################
+
+## To declare and build messages, services or actions from within this
+## package, follow these steps:
+## * Let MSG_DEP_SET be the set of packages whose message types you use in
+##   your messages/services/actions (e.g. std_msgs, actionlib_msgs, ...).
+## * In the file package.xml:
+##   * add a build_depend and a run_depend tag for each package in MSG_DEP_SET
+##   * If MSG_DEP_SET isn't empty the following dependencies might have been
+##     pulled in transitively but can be declared for certainty nonetheless:
+##     * add a build_depend tag for "message_generation"
+##     * add a run_depend tag for "message_runtime"
+## * In this file (CMakeLists.txt):
+##   * add "message_generation" and every package in MSG_DEP_SET to
+##     find_package(catkin REQUIRED COMPONENTS ...)
+##   * add "message_runtime" and every package in MSG_DEP_SET to
+##     catkin_package(CATKIN_DEPENDS ...)
+##   * uncomment the add_*_files sections below as needed
+##     and list every .msg/.srv/.action file to be processed
+##   * uncomment the generate_messages entry below
+##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
+
+## Generate messages in the 'msg' folder
+# add_message_files(
+#   FILES
+#   Message1.msg
+#   Message2.msg
+# )
+
+## Generate services in the 'srv' folder
+# add_service_files(
+#   FILES
+#   Service1.srv
+#   Service2.srv
+# )
+
+## Generate actions in the 'action' folder
+# add_action_files(
+#   FILES
+#   Action1.action
+#   Action2.action
+# )
+
+## Generate added messages and services with any dependencies listed here
+# generate_messages(
+#   DEPENDENCIES
+#   std_msgs
+# )
+
+###################################
+## catkin specific configuration ##
+###################################
+## The catkin_package macro generates cmake config files for your package
+## Declare things to be passed to dependent projects
+## INCLUDE_DIRS: uncomment this if you package contains header files
+## LIBRARIES: libraries you create in this project that dependent projects also need
+## CATKIN_DEPENDS: catkin_packages dependent projects also need
+## DEPENDS: system dependencies of this project that dependent projects also need
+catkin_package(
+#  INCLUDE_DIRS include
+#  LIBRARIES turtlebot_joystick_follower
+#  CATKIN_DEPENDS std_msgs topic_tools
+#  DEPENDS system_lib
+)
+
+###########
+## Build ##
+###########
+
+## Specify additional locations of header files
+## Your package locations should be listed before other locations
+# include_directories(include)
+# include_directories(
+#   ${catkin_INCLUDE_DIRS}
+# )
+
+## Declare a cpp library
+# add_library(turtlebot_joystick_follower
+#   src/${PROJECT_NAME}/turtlebot_joystick_follower.cpp
+# )
+
+## Declare a cpp executable
+# add_executable(turtlebot_joystick_follower_node src/turtlebot_joystick_follower_node.cpp)
+
+## Add cmake target dependencies of the executable/library
+## as an example, message headers may need to be generated before nodes
+# add_dependencies(turtlebot_joystick_follower_node turtlebot_joystick_follower_generate_messages_cpp)
+
+## Specify libraries to link a library or executable target against
+# target_link_libraries(turtlebot_joystick_follower_node
+#   ${catkin_LIBRARIES}
+# )
+
+#############
+## Install ##
+#############
+
+# all install targets should use catkin DESTINATION variables
+# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
+
+## Mark executable scripts (Python etc.) for installation
+## in contrast to setup.py, you can choose the destination
+install(PROGRAMS
+  scripts/switch.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+## Mark executables and/or libraries for installation
+# install(TARGETS turtlebot_joystick_follower turtlebot_joystick_follower_node
+#   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+# )
+
+## Mark cpp header files for installation
+# install(DIRECTORY include/${PROJECT_NAME}/
+#   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+#   FILES_MATCHING PATTERN "*.h"
+#   PATTERN ".svn" EXCLUDE
+# )
+
+## Mark other files for installation (e.g. launch and bag files, etc.)
+# install(FILES
+#   # myfile1
+#   # myfile2
+#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+# )
+
+install(DIRECTORY param
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
+
+install(DIRECTORY launch
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
+
+#############
+## Testing ##
+#############
+
+## Add gtest based cpp test target and link libraries
+# catkin_add_gtest(${PROJECT_NAME}-test test/test_turtlebot_joystick_follower.cpp)
+# if(TARGET ${PROJECT_NAME}-test)
+#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
+# endif()
+
+## Add folders to be run by python nosetests
+# catkin_add_nosetests(test)

--- a/turtlebot_joystick_follower/launch/joystick_follower.launch
+++ b/turtlebot_joystick_follower/launch/joystick_follower.launch
@@ -1,0 +1,6 @@
+<launch>
+<include file="$(find turtlebot_joystick_follower)/launch/minimal.launch.xml"/>
+<include file="$(find turtlebot_teleop)/launch/logitech.launch"/>
+<include file="$(find turtlebot_follower)/launch/follower.launch"/>
+<include file="$(find turtlebot_joystick_follower)/launch/switch.launch.xml"/>
+</launch>

--- a/turtlebot_joystick_follower/launch/minimal.launch.xml
+++ b/turtlebot_joystick_follower/launch/minimal.launch.xml
@@ -1,0 +1,91 @@
+<launch>
+  <!-- Turtlebot -->
+  <arg name="base"              default="$(env TURTLEBOT_BASE)"         doc="mobile base type [create, roomba]"/>
+  <arg name="battery"           default="$(env TURTLEBOT_BATTERY)"      doc="kernel provided locatio for battery info, use /proc/acpi/battery/BAT0 in 2.6 or earlier kernels." />
+  <arg name="stacks"            default="$(env TURTLEBOT_STACKS)"       doc="stack type displayed in visualisation/simulation [circles, hexagons]"/>
+  <arg name="3d_sensor"         default="$(env TURTLEBOT_3D_SENSOR)"    doc="3d sensor types [kinect, asux_xtion_pro]"/>
+  <arg name="simulation"        default="$(env TURTLEBOT_SIMULATION)"   doc="set flags to indicate this turtle is run in simulation mode."/>
+  <arg name="serialport"        default="$(env TURTLEBOT_SERIAL_PORT)"  doc="used by create to configure the port it is connected on [/dev/ttyUSB0, /dev/ttyS0]"/>
+  <arg name="robot_name"        default="$(env TURTLEBOT_NAME)"         doc="used as a unique identifier and occasionally to preconfigure root namespaces, gateway/zeroconf ids etc."/>
+  <arg name="robot_type"        default="$(env TURTLEBOT_TYPE)"         doc="just in case you are considering a 'variant' and want to make use of this."/>
+
+  <param name="/use_sim_time" value="$(arg simulation)"/>
+
+  <include file="$(find turtlebot_bringup)/launch/includes/robot.launch.xml">
+    <arg name="base" value="$(arg base)" />
+    <arg name="stacks" value="$(arg stacks)" />
+    <arg name="3d_sensor" value="$(arg 3d_sensor)" />
+  </include>
+  <include file="$(find turtlebot_joystick_follower)/launch/mobile_base_kobuki.launch.xml">
+    <arg name="serialport" value="$(arg serialport)" />
+  </include>
+  <include file="$(find turtlebot_bringup)/launch/includes/netbook.launch.xml">
+    <arg name="battery" value="$(arg battery)" />
+  </include>
+
+  <!-- Rapp Manager --> 
+  <arg name="rapp_auto_installation"            default="false"  doc="automatically install rapps from the web (not typically used)"/> <!-- http://wiki.ros.org/rocon_app_manager/Tutorials/indigo/Automatic Rapp Installation -->
+  <arg name="rapp_auto_start"                   default=""       doc="pick an app to autostart, e.g. 'rocon_apps/talker'"/>
+  <arg name="rapp_package_whitelist"            default="$(env TURTLEBOT_RAPP_PACKAGE_WHITELIST)" doc="a list of catkin packages that provide rapps to be loaded by the app manager."/>
+  <arg name="rapp_package_blacklist"            default="$(env TURTLEBOT_RAPP_PACKAGE_BLACKLIST)" doc="a list of catkin packages to blacklist from providing rapps."/>
+  <arg name="rapp_preferred_configuration_file" default="$(find turtlebot_bringup)/param/preferred_rapp.yaml" doc="a configuration of preferred rapps"/>
+  <arg name="robot_icon"                        default="turtlebot_bringup/turtlebot2.png"        doc="passed to user interfaces to socialise the turtlebot's appearance"/>
+  <arg name="rapp_verbose"                      default="true"   doc="show verbose output from running apps (aka roslaunch --screen)"/>
+
+  <!-- ***************************** Rocon Master Info ************************** -->
+  <arg name="robot_description"                 default="Kick-ass ROS turtle"/>
+
+  <!-- Capabilities --> 
+  <arg name="capabilities"                      default="true" doc="start and register an underlying capability server"/>
+  <arg name="capabilities_server_name"          default="capability_server"/>
+  <arg name="capabilities_nodelet_manager_name" default="capability_server_nodelet_manager" />
+  <arg name="capabilities_parameters"           default="$(find turtlebot_bringup)/param/capabilities/defaults_tb2.yaml"  doc="preload the capability server with this configurations" /> <!-- defaults_tb.yaml, defaults_tb2.yaml -->
+  <arg name="capabilities_package_whitelist"    default="[kobuki_capabilities, std_capabilities, turtlebot_capabilities]" doc="register capabilities from these packages only" /> 
+  <arg name="capabilities_blacklist"            default="['std_capabilities/Navigation2D', 'std_capabilities/MultiEchoLaserSensor']" doc="blacklist these specific capabilities from being registered" />
+
+  <!-- Interactions --> 
+  <arg name="interactions"      default="true"  doc="start an interactions manager"/>
+  <arg name="interactions_list" default="$(env TURTLEBOT_INTERACTIONS_LIST)" doc="a list of filenames that provide interactions specifications."/>
+
+  <!-- Zeroconf -->
+  <arg name="zeroconf"                          default="true"              doc="publish the master information on zeroconf"/>
+  <arg name="zeroconf_name"                     default="$(arg robot_name)" doc="the name to identify the master on zeroconf"/>
+  <arg name="zeroconf_port"                     default="11311"             doc="port number of the ros master"/>
+
+  <!-- Rapp Manager -->
+  <include file="$(find rocon_app_manager)/launch/standalone.launch">
+
+    <!-- Rapp Manager --> 
+    <arg name="robot_name"                        value="$(arg robot_name)" />
+    <arg name="robot_type"                        value="$(arg robot_type)" />
+    <arg name="robot_icon"                        value="$(arg robot_icon)" />
+    <arg name="rapp_package_whitelist"            value="$(arg rapp_package_whitelist)" />
+    <arg name="rapp_package_blacklist"            value="$(arg rapp_package_blacklist)" />
+    <arg name="rapp_preferred_configuration_file" value="$(arg rapp_preferred_configuration_file)" />
+    <arg name="auto_start_rapp"                   value="$(arg rapp_auto_start)" />
+    <arg name="screen"                            value="$(arg rapp_verbose)" />
+    <arg name="auto_rapp_installation"            value="$(arg rapp_auto_installation)" />
+
+    <!-- Rocon Master Info -->
+    <arg name="robot_description"                 value="$(arg robot_description)" />
+
+    <!-- Capabilities --> 
+    <arg name="capabilities"                      value="$(arg capabilities)" />
+    <arg name="capabilities_blacklist"            value="$(arg capabilities_blacklist)" />
+    <arg name="capabilities_nodelet_manager_name" value="$(arg capabilities_nodelet_manager_name)" />
+    <arg name="capabilities_server_name"          value="$(arg capabilities_server_name)" />
+    <arg name="capabilities_package_whitelist"    value="$(arg capabilities_package_whitelist)" />
+    <arg name="capabilities_parameters"           value="$(arg capabilities_parameters)" />
+
+    <!-- Interactions --> 
+    <arg name="interactions"                      value="$(arg interactions)"/>
+    <arg name="interactions_list"                 value="$(arg interactions_list)"/>
+
+    <!-- Zeroconf --> 
+    <arg name="zeroconf"                          value="$(arg zeroconf)"/>
+    <arg name="zeroconf_name"                     value="$(arg zeroconf_name)"/>
+    <arg name="zeroconf_port"                     value="$(arg zeroconf_port)"/>
+
+  </include>
+
+</launch>

--- a/turtlebot_joystick_follower/launch/mobile_base_kobuki.launch.xml
+++ b/turtlebot_joystick_follower/launch/mobile_base_kobuki.launch.xml
@@ -1,0 +1,29 @@
+<!--
+  Kobuki's implementation of turtlebot's mobile base.
+ -->
+<launch>
+  <arg name="serialport"/> <!-- TODO: use the serialport parameter to set the serial port of kobuki -->
+  
+  <node pkg="nodelet" type="nodelet" name="mobile_base_nodelet_manager" args="manager"/>
+  <node pkg="nodelet" type="nodelet" name="mobile_base" args="load kobuki_node/KobukiNodelet mobile_base_nodelet_manager">
+    <rosparam file="$(find kobuki_node)/param/base.yaml" command="load"/>
+    <param name="device_port" value="$(arg serialport)" />
+
+    <remap from="mobile_base/odom" to="odom"/>
+    <!-- Don't do this - force applications to use a velocity mux for redirection  
+      <remap from="mobile_base/commands/velocity" to="cmd_vel"/> 
+    -->
+    <remap from="mobile_base/enable" to="enable"/>
+    <remap from="mobile_base/disable" to="disable"/>
+    <remap from="mobile_base/joint_states" to="joint_states"/>
+  </node>
+
+  <!-- velocity commands multiplexer -->
+  <node pkg="nodelet" type="nodelet" name="cmd_vel_mux" args="load yocs_cmd_vel_mux/CmdVelMuxNodelet mobile_base_nodelet_manager">
+    <param name="yaml_cfg_file" value="$(find turtlebot_joystick_follower)/param/mux.yaml"/>
+    <remap from="cmd_vel_mux/output" to="mobile_base/commands/velocity"/>
+  </node>
+  
+  <!-- bumper/cliff to pointcloud -->
+  <include file="$(find turtlebot_bringup)/launch/includes/kobuki/bumper2pc.launch.xml"/>
+</launch>

--- a/turtlebot_joystick_follower/launch/switch.launch.xml
+++ b/turtlebot_joystick_follower/launch/switch.launch.xml
@@ -1,0 +1,3 @@
+<launch>
+<node name="switch" pkg="turtlebot_joystick_follower" type="switch.py"/>
+</launch>

--- a/turtlebot_joystick_follower/package.xml
+++ b/turtlebot_joystick_follower/package.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0"?>
+<package>
+  <name>turtlebot_joystick_follower</name>
+  <version>0.0.0</version>
+  <description>The turtlebot_joystick_follower package
+  
+  This is a demo of the follower which can be started and stopped and remotely controlled via the joystick.
+  It is designed to be launched on startup and does not require a wireless connection.
+  </description>
+
+  <!-- One maintainer tag required, multiple allowed, one person per tag -->
+  <!-- Example:  -->
+  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
+  <maintainer email="tfoote@osrfoundation.org">Tully Foote</maintainer>
+  <author>Esteve Fernandez</author>
+
+  <!-- One license tag required, multiple allowed, one license per tag -->
+  <!-- Commonly used license strings: -->
+  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
+  <license>Apache 2.0</license>
+
+
+  <!-- Url tags are optional, but mutiple are allowed, one per tag -->
+  <!-- Optional attribute type can be: website, bugtracker, or repository -->
+  <!-- Example: -->
+  <!-- <url type="website">http://wiki.ros.org/turtlebot_joystick_follower</url> -->
+
+
+  <!-- Author tags are optional, mutiple are allowed, one per tag -->
+  <!-- Authors do not have to be maintianers, but could be -->
+  <!-- Example: -->
+  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
+
+
+  <!-- The *_depend tags are used to specify dependencies -->
+  <!-- Dependencies can be catkin packages or system dependencies -->
+  <!-- Examples: -->
+  <!-- Use build_depend for packages you need at compile time: -->
+  <!--   <build_depend>message_generation</build_depend> -->
+  <!-- Use buildtool_depend for build tool packages: -->
+  <!--   <buildtool_depend>catkin</buildtool_depend> -->
+  <!-- Use run_depend for packages you need at runtime: -->
+  <!--   <run_depend>message_runtime</run_depend> -->
+  <!-- Use test_depend for packages you need only for testing: -->
+  <!--   <test_depend>gtest</test_depend> -->
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>topic_tools</build_depend>
+  <run_depend>kobuki_node</run_depend>
+  <run_depend>std_msgs</run_depend>
+  <run_depend>topic_tools</run_depend>
+  <run_depend>turtlebot_follower</run_depend>
+  <run_depend>turtlebot_teleop</run_depend>
+
+
+  <!-- The export tag contains other, unspecified, tags -->
+  <export>
+    <!-- Other tools can request additional information be placed here -->
+
+  </export>
+</package>

--- a/turtlebot_joystick_follower/param/mux.yaml
+++ b/turtlebot_joystick_follower/param/mux.yaml
@@ -1,0 +1,28 @@
+# Created on: Oct 29, 2012
+#     Author: jorge
+# Configuration for subscribers to multiple cmd_vel sources.
+#
+# Individual subscriber configuration:
+#   name:           Source name
+#   topic:          The topic that provides cmd_vel messages
+#   timeout:        Time in seconds without incoming messages to consider this topic inactive
+#   priority:       Priority: an UNIQUE unsigned integer from 0 (lowest) to MAX_INT 
+#   short_desc:     Short description (optional)
+
+subscribers:
+  - name:        "Safe reactive controller"
+    topic:       "input/safety_controller"
+    timeout:     0.2
+    priority:    10
+  - name:        "Teleoperation"
+    topic:       "input/teleop"
+    timeout:     1.0
+    priority:    7
+  - name:        "Switch"
+    topic:       "input/switch"
+    timeout:     1.0
+    priority:    6
+  - name:        "Navigation"
+    topic:       "input/navi"
+    timeout:     1.0
+    priority:    5

--- a/turtlebot_joystick_follower/scripts/switch.py
+++ b/turtlebot_joystick_follower/scripts/switch.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+# license removed for brevity
+import rospy
+from std_msgs.msg import String
+from geometry_msgs.msg import Twist
+from sensor_msgs.msg import Joy
+
+class BehaviorSwitch(object):
+    def __init__(self):
+        self.running = False
+
+    def callback(self, joy_msg):
+        if joy_msg.buttons[5] == 1:
+            self.running = not self.running
+
+        rospy.loginfo(repr(joy_msg))
+
+    def run(self):
+        rospy.init_node('behavior_switch', anonymous=True)
+        pub = rospy.Publisher('cmd_vel_mux/input/switch', Twist, queue_size=10)
+        rospy.Subscriber('joy', Joy, self.callback)
+        rate = rospy.Rate(10)
+        while not rospy.is_shutdown():
+            if self.running:
+                empty_msg = Twist()
+                pub.publish(empty_msg)
+            rate.sleep()
+
+if __name__ == '__main__':
+    try:
+        behavior_switch = BehaviorSwitch()
+        behavior_switch.run()
+    except rospy.ROSInterruptException:
+        pass


### PR DESCRIPTION
A neat demo we've been running integrating joystick control of the follower app for enabling/disabling and remote control. 

Looking at this PR we should probably rename the package. Any other thoughts. I will also want to improve the documentation, but I'm opening the PR for higher visibility. 
