### PR TITLE
Add support for joystick override of follower

### DIFF
--- a/turtlebot_follower/CMakeLists.txt
+++ b/turtlebot_follower/CMakeLists.txt
@@ -63,6 +63,13 @@ install(DIRECTORY plugins
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
 
+## Mark executable scripts (Python etc.) for installation
+## in contrast to setup.py, you can choose the destination
+install(PROGRAMS
+  scripts/switch.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
 #############
 ## Testing ##
 #############

--- a/turtlebot_follower/launch/follower.launch
+++ b/turtlebot_follower/launch/follower.launch
@@ -53,4 +53,6 @@
     <param name="max_z" value="1.2" />
     <param name="goal_z" value="0.6" />
   </node>
+  <!-- Launch the script which will toggle turtlebot following on and off based on a joystick button. default: on -->
+  <node name="switch" pkg="turtlebot_follower" type="switch.py"/>
 </launch>

--- a/turtlebot_follower/package.xml
+++ b/turtlebot_follower/package.xml
@@ -29,7 +29,9 @@
   <run_depend>roscpp</run_depend>
   <run_depend>visualization_msgs</run_depend>
   <run_depend>dynamic_reconfigure</run_depend>
+  <run_depend>topic_tools</run_depend>
   <run_depend>turtlebot_bringup</run_depend>
+  <run_depend>turtlebot_teleop</run_depend>
   <run_depend>turtlebot_msgs</run_depend>
 
   <export>

--- a/turtlebot_follower/scripts/switch.py
+++ b/turtlebot_follower/scripts/switch.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+# license removed for brevity
+import rospy
+from geometry_msgs.msg import Twist
+from sensor_msgs.msg import Joy
+
+# This script will listen for joystick button 5 being toggled and
+# send zero speed messages to the mux to disable the follower until
+# button 5 is pressed again.
+
+class BehaviorSwitch(object):
+    def __init__(self):
+        self.running = False
+
+    def callback(self, joy_msg):
+        if joy_msg.buttons[5] == 1:
+            self.running = not self.running
+
+        rospy.loginfo(repr(joy_msg))
+
+    def run(self):
+        rospy.init_node('behavior_switch', anonymous=True)
+        pub = rospy.Publisher('cmd_vel_mux/input/switch', Twist, queue_size=10)
+        rospy.Subscriber('joy', Joy, self.callback)
+        rate = rospy.Rate(10)
+        while not rospy.is_shutdown():
+            if self.running:
+                empty_msg = Twist()
+                pub.publish(empty_msg)
+            rate.sleep()
+
+if __name__ == '__main__':
+    try:
+        behavior_switch = BehaviorSwitch()
+        behavior_switch.run()
+    except rospy.ROSInterruptException:
+        pass


### PR DESCRIPTION
This allows joystick button 5 to toggle follower on and off.
It simply adds another input to the mux which sends zero
velocity with a slightly higher priority than the follower.

This integrates the features of #141 into the main follower demo. 
