### PR TITLE
[WIP] Integrate frontier_exploration.

### DIFF
--- a/turtlebot_samples/CMakeLists.txt
+++ b/turtlebot_samples/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(turtlebot_samples)
+
+find_package(catkin REQUIRED COMPONENTS
+  frontier_exploration
+  turtlebot_navigation
+)
+
+# catkin_python_setup()
+
+catkin_package(
+#  INCLUDE_DIRS include
+#  LIBRARIES turtlebot_samples
+#  CATKIN_DEPENDS frontier_exploration frontier_exploration turtlebot_navigation
+#  DEPENDS system_lib
+)
+
+install(DIRECTORY launch
+        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
+
+if (CATKIN_ENABLE_TESTING)
+  find_package(rostest)
+  add_rostest(test/frontier.test)
+endif()

--- a/turtlebot_samples/launch/exploration.launch
+++ b/turtlebot_samples/launch/exploration.launch
@@ -1,0 +1,14 @@
+<launch> <!-- Edited from https://github.com/husky/husky/blob/8cd932ac230b87ba0ce59b75908b759f4065a6c1/husky_navigation/launch/exploration.launch -->
+  <node pkg="frontier_exploration" type="explore_client" name="explore_client" output="screen"/>
+
+  <node pkg="frontier_exploration" type="explore_server" name="explore_server" output="screen">
+    <param name="frequency" value="1.0"/>
+
+    <!-- Should be less than sensor range -->
+    <param name="goal_aliasing" value="2.0"/>
+    
+    <rosparam file="$(find turtlebot_navigation)/param/costmap_common_params.yaml" command="load" ns="explore_costmap" />
+    <rosparam file="$(find turtlebot_navigation)/param/costmap_exploration.yaml" command="load" ns="explore_costmap" />
+  </node>
+
+</launch>

--- a/turtlebot_samples/package.xml
+++ b/turtlebot_samples/package.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<package>
+  <name>turtlebot_samples</name>
+  <version>2.3.3</version>
+  <description>Collection of miscellaneous samples of Turtlebot that may not be big enough to be a package.</description>
+
+  <maintainer email="iisaito@kinugarage.com">Isaac I. Y. Saito</maintainer>
+  <author email="iiysaito@opensource-robotics.tokyo.jp">Isaac I. Y. Saito</author>
+
+  <license>BSD</license>
+  <url type="website">http://wiki.ros.org/turtlebot_samples</url>
+  <url type="repository">https://github.com/turtlebot/turtlebot_apps</url>
+  <url type="bugtracker">https://github.com/turtlebot/turtlebot_apps/issues</url>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <run_depend>frontier_exploration</run_depend>
+  <run_depend>turtlebot_navigation</run_depend>
+  <test_depend>rostest</test_depend>
+
+  <export/>
+
+</package>

--- a/turtlebot_samples/param/costmap_exploration.yaml
+++ b/turtlebot_samples/param/costmap_exploration.yaml
@@ -1,0 +1,17 @@
+# Taken from https://github.com/husky/husky/blob/8cd932ac230b87ba0ce59b75908b759f4065a6c1/husky_navigation/config/costmap_exploration.yaml
+track_unknown_space: true
+global_frame: map
+rolling_window: false
+
+plugins: 
+- {name: external,            type: "costmap_2d::StaticLayer"}
+- {name: explore_boundary,    type: "frontier_exploration::BoundedExploreLayer"}
+#Can disable sensor layer if gmapping is fast enough to update scans
+- {name: obstacles_laser,     type: "costmap_2d::ObstacleLayer"}
+- {name: inflation,           type: "costmap_2d::InflationLayer"}
+
+explore_boundary:
+  resize_to_boundary: false
+  frontier_travel_point: middle
+  #set to false for gmapping, true if re-exploring a known area
+  explore_clear_space: false


### PR DESCRIPTION
**Do not review yet, but opinion needed.**

Adding a launch and a param file for [frontier_exploration](http://wiki.ros.org/frontier_exploration). 

**Question**. Particularly because I'm adding dependency, I thought I would add this as a separate package (e.g. turtlebot_samples). However, I'm not adding a sample, instead I'm adding a feature that user's application can utilize, thus I'm adding as another feature in `turtlebot_navigation`. Is this okay approach?
