### PR TITLE
remove superfluous leading '/' in topic names

### DIFF
--- a/turtlebot_navigation/launch/includes/safety_controller.launch.xml
+++ b/turtlebot_navigation/launch/includes/safety_controller.launch.xml
@@ -2,10 +2,10 @@
     Safety controller
 -->
 <launch>
-  <node pkg="nodelet" type="nodelet" name="kobuki_safety_controller" args="load kobuki_safety_controller/SafetyControllerNodelet /mobile_base_nodelet_manager">
-    <remap from="kobuki_safety_controller/cmd_vel" to="/cmd_vel_mux/input/safety_controller"/>
-    <remap from="kobuki_safety_controller/events/bumper" to="/mobile_base/events/bumper"/>
-    <remap from="kobuki_safety_controller/events/cliff" to="/mobile_base/events/cliff"/>
-    <remap from="kobuki_safety_controller/events/wheel_drop" to="/mobile_base/events/wheel_drop"/>
+  <node pkg="nodelet" type="nodelet" name="kobuki_safety_controller" args="load kobuki_safety_controller/SafetyControllerNodelet mobile_base_nodelet_manager">
+    <remap from="kobuki_safety_controller/cmd_vel" to="cmd_vel_mux/input/safety_controller"/>
+    <remap from="kobuki_safety_controller/events/bumper" to="mobile_base/events/bumper"/>
+    <remap from="kobuki_safety_controller/events/cliff" to="mobile_base/events/cliff"/>
+    <remap from="kobuki_safety_controller/events/wheel_drop" to="mobile_base/events/wheel_drop"/>
   </node>
 </launch>

--- a/turtlebot_navigation/launch/includes/velocity_smoother.launch.xml
+++ b/turtlebot_navigation/launch/includes/velocity_smoother.launch.xml
@@ -2,12 +2,12 @@
          Velocity smoother
 -->
 <launch>
-  <node pkg="nodelet" type="nodelet" name="navigation_velocity_smoother" args="load yocs_velocity_smoother/VelocitySmootherNodelet /mobile_base_nodelet_manager">
+  <node pkg="nodelet" type="nodelet" name="navigation_velocity_smoother" args="load yocs_velocity_smoother/VelocitySmootherNodelet mobile_base_nodelet_manager">
     <rosparam file="$(find turtlebot_bringup)/param/defaults/smoother.yaml" command="load"/>
-    <remap from="navigation_velocity_smoother/smooth_cmd_vel" to="/cmd_vel_mux/input/navi"/>
+    <remap from="navigation_velocity_smoother/smooth_cmd_vel" to="cmd_vel_mux/input/navi"/>
 
     <!-- Robot velocity feedbacks; use the default base configuration -->
-    <remap from="navigation_velocity_smoother/odometry" to="/odom"/>
-    <remap from="navigation_velocity_smoother/robot_cmd_vel" to="/mobile_base/commands/velocity"/>
+    <remap from="navigation_velocity_smoother/odometry" to="odom"/>
+    <remap from="navigation_velocity_smoother/robot_cmd_vel" to="mobile_base/commands/velocity"/>
   </node>
 </launch>


### PR DESCRIPTION
These are not needed as all topics in question are in the same namespace as
the nodes. However, the '/' breaks namespacing, so it becomes impossible to
move the whole launch file into a new namespace.
