### PR TITLE
[CI] Add Travis config to test Indigo and Kinetic.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+# This config file for Travis CI utilizes ros-industrial/industrial_ci package.
+# For more info for the package, see https://github.com/ros-industrial/industrial_ci/blob/master/README.rst
+sudo: required 
+dist: trusty 
+services:
+  - docker
+language: generic 
+compiler:
+  - gcc
+notifications:
+  email:
+    recipients:
+      - gm130s@gmail.com
+env:
+  matrix:
+    - ROS_DISTRO="indigo"  ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - ROS_DISTRO="indigo"  ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+    - ROS_DISTRO="indigo"  PRERELEASE=true
+    - ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+    - ROS_DISTRO="kinetic" PRERELEASE=true
+matrix:
+  allow_failures:
+    # Run docker-based ROS prerelease test http://wiki.ros.org/bloom/Tutorials/PrereleaseTest Because we might not want to run prerelease test for all PRs, it's omitted from pass-fail criteria.
+    - env: ROS_DISTRO="indigo"  PRERELEASE=true
+    - env: ROS_DISTRO="kinetic" PRERELEASE=true
+before_script:
+  - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
+script:
+  - source .ci_config/travis.sh
+#  - source ./travis.sh  # Enable this when you have a package-local script 


### PR DESCRIPTION
[industrial_ci](https://github.com/ros-industrial/industrial_ci/blob/master/README.rst) is a set of CI configs hosted on another repository. For each run of Travis your jobs fetch the latest config by `git clone`.

I tested yesterday on my forked repo, and only `kinetic` with official DEB repository failed, which I think is expected.

If this is good then please any admin enable Travis for this repo https://travis-ci.org/profile/turtlebot by a few clicks to get the checking started.
