### PR TITLE
Increase min max obstacle height for scan topic

### DIFF
--- a/turtlebot_navigation/param/costmap_common_params.yaml
+++ b/turtlebot_navigation/param/costmap_common_params.yaml
@@ -28,8 +28,8 @@ obstacle_layer:
     topic: scan
     marking: true
     clearing: true
-    min_obstacle_height: 0.25
-    max_obstacle_height: 0.35
+    min_obstacle_height: 0.20
+    max_obstacle_height: 0.41
   bump:
     data_type: PointCloud2
     topic: mobile_base/sensors/bumper_pointcloud


### PR DESCRIPTION
Adjust the values so that it is possible to mount another laserscan source anywhere on the turtlebot.

In our setup we use, besides the kinect, a laserscanner which scans the field behind the turtlebot.
This scanner is placed above the kinect and publishes data with a higher value than the max_obstacle height,
in this case it is not possible to use the data for navigation and localization.

As you can see in the picture, the old values (red) are overly restrictive and there shouldn't be any harm in adjusting them to the new values (green).
![tb](https://cloud.githubusercontent.com/assets/18333271/19765769/7c4acb62-9c4a-11e6-9fd5-653516ba7e5e.jpg)
