### PR TITLE
Use GMapping nodelet

### DIFF
--- a/turtlebot_navigation/launch/includes/gmapping/gmapping.launch.xml
+++ b/turtlebot_navigation/launch/includes/gmapping/gmapping.launch.xml
@@ -3,7 +3,7 @@
   <arg name="base_frame"  default="base_footprint"/>
   <arg name="odom_frame"  default="odom"/>
 
-  <node pkg="gmapping" type="slam_gmapping" name="slam_gmapping" output="screen">
+  <node pkg="nodelet" type="nodelet" name="slam_gmapping" args="load SlamGMappingNodelet camera/camera_nodelet_manager" output="screen">
     <param name="base_frame" value="$(arg base_frame)"/>
     <param name="odom_frame" value="$(arg odom_frame)"/>
     <param name="map_update_interval" value="5.0"/>
@@ -44,6 +44,9 @@
     <param name="llsamplestep" value="0.01"/>
     <param name="lasamplerange" value="0.005"/>
     <param name="lasamplestep" value="0.005"/>
-    <remap from="scan" to="$(arg scan_topic)"/>
+    
+    <remap from="camera/scan" to="$(arg scan_topic)"/>
+    <remap from="camera/map" to="map"/>
+    <remap from="camera/map_metadata" to="map_metadata"/>
   </node>
 </launch>

--- a/turtlebot_navigation/launch/includes/gmapping/r200_gmapping.launch.xml
+++ b/turtlebot_navigation/launch/includes/gmapping/r200_gmapping.launch.xml
@@ -4,7 +4,7 @@
   <arg name="base_frame"  default="base_footprint"/>
   <arg name="odom_frame"  default="odom"/>
 
-  <node pkg="gmapping" type="slam_gmapping" name="slam_gmapping" output="screen">
+  <node pkg="nodelet" type="nodelet" name="slam_gmapping" args="load SlamGMappingNodelet camera/camera_nodelet_manager" output="screen">
     <param name="base_frame" value="$(arg base_frame)"/>
     <param name="odom_frame" value="$(arg odom_frame)"/>
     <param name="map_update_interval" value="5.0"/>
@@ -39,6 +39,9 @@
     <param name="llsamplestep" value="0.01"/>
     <param name="lasamplerange" value="0.005"/>
     <param name="lasamplestep" value="0.005"/>
-    <remap from="scan" to="$(arg scan_topic)"/>
+    
+    <remap from="camera/scan" to="$(arg scan_topic)"/>
+    <remap from="camera/map" to="map"/>
+    <remap from="camera/map_metadata" to="map_metadata"/>
   </node>
 </launch>


### PR DESCRIPTION
Modified GMapping launch files to use the new nodelet
version of gmapping instead of the older node. This
allows the GMapping nodelet (which reads /scan) to be
run in the same nodelet manager as depthimage_to_laserscan
(which outputs /scan), allowing for more efficient
data processing.

Note that this was done in conjunction with a forthcoming change to the gmapping package (pull request: https://github.com/ros-perception/slam_gmapping/pull/41), and serves as an example of the two nodelets running together under the same nodelet manager. Initial testing showed a ~11% reduction in overall memory usage and ~20% CPU usage running the slam_gmapping nodelet and depthimage_to_laserscan nodelet together, as compared to running slam_gmapping in a separate node.  This PR is thus dependent on the above-linked PR, and needs that to land before it can be merged in.