### PR TITLE
Removed duplicate entries in costmap_common_params.yaml.

### DIFF
--- a/turtlebot_navigation/param/costmap_common_params.yaml
+++ b/turtlebot_navigation/param/costmap_common_params.yaml
@@ -9,9 +9,6 @@ map_type: voxel
 obstacle_layer:
   enabled:              true
   max_obstacle_height:  0.6
-  origin_z:             0.0
-  z_resolution:         0.2
-  z_voxels:             2
   unknown_threshold:    15
   mark_threshold:       0
   combination_method:   1
@@ -47,5 +44,3 @@ inflation_layer:
 
 static_layer:
   enabled:              true
-  
-


### PR DESCRIPTION
The parameters `origin_z`, `z_resolution` and `z_voxels` are listed two times in the common costmap parameters. Can we remove the duplicates?